### PR TITLE
Update fxmanifest.lua qr-core to rsg-core

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -11,6 +11,6 @@ client_scripts {
 }
 
 dependencies {
-    'qr-core',
-	'qr-menu',
+    'rsg-core',
+	'rsg-menu',
 }


### PR DESCRIPTION
The qr-core dependency was not found, so I replaced it with rsg-core